### PR TITLE
「取消」したあとの合計がおかしくなるのを修正

### DIFF
--- a/models/transaction.go
+++ b/models/transaction.go
@@ -1,12 +1,13 @@
 package models
 
-import "github.com/jinzhu/gorm"
+import "time"
 
 // Transaction model
 type Transaction struct {
-	gorm.Model
-	UserID  uint
-	GameID  uint
-	Amount  int  `gorm:"not null"`
-	IsBuyin bool `gorm:"not null;default:0"`
+	ID        uint `gorm:"primary_key"`
+	CreatedAt time.Time
+	UserID    uint
+	GameID    uint
+	Amount    int  `gorm:"not null"`
+	IsBuyin   bool `gorm:"not null;default:0"`
 }


### PR DESCRIPTION
Fix #7

## バグはどんなの

- 実際に稼働してみて出てきたバグ
- 「取消」でtransactionsを削除するとその後の現在額がおかしくなる

## なにした

- `gorm` が勝手にやってた `transactions` の論理削除が物理削除になるように
  - 現在額は `SUM()` で出してるが、そこが論理削除レコードも計算されおかしくなった
  - カラム `deleted_at` の削除
  - テーブル的に論理削除の必要はまったくない、HerokuのClearDBも無料枠は容量ベースなのでなるべく物理削除のほうが何かとメリットづくめ
- ついでにいらないカラム `updated_at` も削除
  - これもテーブル的に必要無い（後から更新するレコードではない）ので

## マイグレーション
- 本番DBから `transactions.updated_at` 及び `transactions.deleted_at` を手動で削除する
  - `gorm` の AutoMigration ではカラムの削除とかはしないので
- 今は誰も使ってないので気軽に

## テスト書けよ
- えー