### PR TITLE
現在額とバイイン額の差額を表示するように

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"math"
 	"net/http"
 	"regexp"
 	"sort"
@@ -91,8 +92,10 @@ func main() {
 			UpdatedAt     time.Time
 		}
 		type TotalStat struct {
-			CurrentAmount int
-			BuyinAmount   int
+			CurrentAmount       int
+			BuyinAmount         int
+			DifferenceAmount    int
+			DifferenceAbsAmount int
 		}
 		var stats []Stat
 		var totalstat TotalStat
@@ -127,6 +130,8 @@ func main() {
 				stats[i].ROI = float64(s.CurrentAmount)/float64(s.BuyinAmount)*100 - 100
 			}
 		}
+		totalstat.DifferenceAmount = totalstat.CurrentAmount - totalstat.BuyinAmount
+		totalstat.DifferenceAbsAmount = int(math.Abs(float64(totalstat.DifferenceAmount)))
 		sort.Slice(stats, func(i, j int) bool {
 			return stats[i].StartedAt.Before(stats[j].StartedAt)
 		})

--- a/templates/result.tmpl.html
+++ b/templates/result.tmpl.html
@@ -32,12 +32,12 @@
       </tr>
       {{end}}
       {{if gt .totalstat.CurrentAmount 0}}
-      <tr class="table-{{if eq .totalstat.CurrentAmount .totalstat.BuyinAmount}}success{{else}}danger{{end}}">
+      <tr class="{{if eq .totalstat.DifferenceAmount 0}}table-success{{else}}table-danger text-danger{{end}}">
         <td>&nbsp;</td>
         <td class="text-right">{{.totalstat.CurrentAmount}}</td>
         <td class="text-right">{{.totalstat.BuyinAmount}}</td>
         <td colspan="2">
-          →{{if eq .totalstat.CurrentAmount .totalstat.BuyinAmount}}OK！{{else}}差異があります{{end}}
+          →&nbsp;{{if eq .totalstat.DifferenceAmount 0}}OK！{{else}}{{if gt .totalstat.DifferenceAmount 0}}現在額{{else if lt .totalstat.DifferenceAmount 0}}バイイン額{{end}}が&nbsp;<strong>{{.totalstat.DifferenceAbsAmount}}</strong>&nbsp;大きいです{{end}}
         </td>
       </tr>
       {{end}}


### PR DESCRIPTION
Fix #12

## なにした
- 差額を「hogehogeが 000 大きいです」と表示するように
  - ただプラスマイナス出すとどっちがどっちかわからないので主語もつけた
- ちょっとだけ差額表示のところのフォント色変えた