### PR TITLE
結果ページのデザイン改善

### DIFF
--- a/static/result.js
+++ b/static/result.js
@@ -3,4 +3,10 @@ setTimeout(function () {
 }, 5000);
 
 (function() {
+    function number_format(num) {
+        return num.toString().replace(/([0-9]+?)(?=(?:[0-9]{3})+$)/g , '$1,');
+    }
+    $('.number-format').text(function(i, e) {
+        return number_format(e);
+    })
 })();

--- a/templates/header.tmpl.html
+++ b/templates/header.tmpl.html
@@ -1,5 +1,6 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
 <link rel="stylesheet" type="text/css" href="/static/main.css" />
 <title>Totsuka Poker School Bot</title>

--- a/templates/result.tmpl.html
+++ b/templates/result.tmpl.html
@@ -7,12 +7,11 @@
 <body>
 <div class="container-fluid">
   <h1>{{.game.Name}}</h1>
-  <p>{{.game.StartedAt.Format "2006/1/2 15:04"}}〜{{.game.EndedAt.Format "2006/1/2 15:04"}}</p>
-  <p class="text-info">{{.currentTime.Format "15:04:05"}}時点</p>
+  <p class="lead text-secondary"><i class="fas fa-calendar-alt"></i>&nbsp;{{.game.StartedAt.Format "2006/1/2 15:04"}}〜{{.game.EndedAt.Format "15:04"}}</p>
   <table id="stats" class="table table-striped table-bordered">
     <thead class="thead-light">
       <tr>
-        <th>名前</th>
+        <th><i class="far fa-user-circle"></i>&nbsp;名前</th>
         <th>現在額</th>
         <th>バイイン</th>
         <th>ROI</th>
@@ -23,8 +22,8 @@
       {{range .stats}}
       <tr>
         <td><img src="{{.User.PictureURL}}" width="30" height="30">{{.User.Name}}</td>
-        <td class="text-right">{{.CurrentAmount}}</td>
-        <td class="text-right">{{.BuyinAmount}}</td>
+        <td class="text-right number-format">{{.CurrentAmount}}</td>
+        <td class="text-right number-format">{{.BuyinAmount}}</td>
         <td class="text-right text-{{if gt .ROI 0.0}}primary{{else if lt .ROI 0.0}}danger{{else}}dark{{end}}">
           {{if gt .ROI 0.0}}+{{end}}{{printf "%.1f" .ROI}}%
         </td>
@@ -34,15 +33,17 @@
       {{if gt .totalstat.CurrentAmount 0}}
       <tr class="{{if eq .totalstat.DifferenceAmount 0}}table-success{{else}}table-danger text-danger{{end}}">
         <td>&nbsp;</td>
-        <td class="text-right">{{.totalstat.CurrentAmount}}</td>
-        <td class="text-right">{{.totalstat.BuyinAmount}}</td>
+        <td class="text-right number-format">{{.totalstat.CurrentAmount}}</td>
+        <td class="text-right number-format">{{.totalstat.BuyinAmount}}</td>
         <td colspan="2">
-          →&nbsp;{{if eq .totalstat.DifferenceAmount 0}}OK！{{else}}{{if gt .totalstat.DifferenceAmount 0}}現在額{{else if lt .totalstat.DifferenceAmount 0}}バイイン額{{end}}が&nbsp;<strong>{{.totalstat.DifferenceAbsAmount}}</strong>&nbsp;大きいです{{end}}
+          {{if eq .totalstat.DifferenceAmount 0}}<i class="fas fa-thumbs-up"></i>&nbsp;OK！{{else}}<i class="fas fa-exclamation-triangle"></i>&nbsp;{{if gt .totalstat.DifferenceAmount 0}}現在額{{else if lt .totalstat.DifferenceAmount 0}}バイイン額{{end}}が&nbsp;<strong class="number-format">{{.totalstat.DifferenceAbsAmount}}</strong>&nbsp;大きいです{{end}}
         </td>
       </tr>
       {{end}}
     </tbody>
   </table>
+
+  <p class="text-black-50 text-center font-weight-light"><i class="far fa-clock"></i>&nbsp;{{.currentTime.Format "2006/1/2 15:04:05"}}</p>
 
   <div class="table-responsive">
     <table id="logs" class="table table-dark table-borderless table-sm">
@@ -59,8 +60,8 @@
         <tr>
           <td>{{.User.Name}}</td>
           <td>{{if .IsBuyin}}バイイン{{else}}現在額{{end}}</td>
-          <td class="text-right">{{if gt .Amount 0}}+{{end}}{{.Amount}}</td>
-          <td>{{.CreatedAt}}</td>
+          <td class="text-right number-format">{{if gt .Amount 0}}+{{end}}{{.Amount}}</td>
+          <td>{{.CreatedAt.Format "2006/1/2 15:04:05"}}</td>
         </tr>
         {{end}}
       </tbody>


### PR DESCRIPTION
### なにした
- 数字に見やすくなるカンマをつけた (#4)
- 現在時刻の表示のリレイアウト
- Font Awesome を使ってちょっとかわいく

### BEFORE/AFTER
|BEFORE|AFTER|
|-|-|
|<img src="https://user-images.githubusercontent.com/696261/48639622-77cef780-ea17-11e8-8abf-dab4d67ffe32.png" width="300">|NOTYET|

close #4